### PR TITLE
Update bin script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "bin": {
+    "start": "./lib/index.js",
     "canvas-simulator-start": "./lib/index.js"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "bin": {
-    "start": "./lib/index.js"
+    "canvas-simulator-start": "./lib/index.js"
   },
   "scripts": {
     "build": "rimraf lib/ && tsc --project ./tsconfig.json && copyfiles -u 1 src/**/*.ejs lib/"


### PR DESCRIPTION
The current `bin` script is called `start`, which conflicts with the `start`script of a CACCL project's `package.json`. I propose to rename it to something more descriptive like `canvas-simulator-start` so it can be used like this:
```
"scripts": {
  "dev:canvas": "npm run canvas-simulator-start"
},
```

instead of this:
```
"scripts": {
  "dev:canvas": "node ./node_modules/caccl-canvas-partial-simulator/lib/index.js"
},
```

PS: This will also allow for other package managers to be used that don't rely on the `node_modules` folder, like Yarn.